### PR TITLE
Add system config schema and validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.env

--- a/TECH_DEBT_LOG.md
+++ b/TECH_DEBT_LOG.md
@@ -1,0 +1,7 @@
+# Tech Debt Log
+
+Registre aqui decisões técnicas que requerem revisões futuras ou potenciais refatorações.
+
+## Entradas
+
+- *[2024-05-10]* Estrutura inicial do `system_config` definida de forma simples; poderá ser expandida para suportar hierarquias de equipes e permissões.

--- a/config_models.py
+++ b/config_models.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class LLMProfile(BaseModel):
+    provider: str = Field(..., description="LLM service provider identifier")
+    model: str = Field(..., description="Model name or identifier")
+    temperature: Optional[float] = Field(
+        0.0, ge=0.0, le=1.0, description="Sampling temperature for the model"
+    )
+
+
+class Agent(BaseModel):
+    description: str = Field(..., description="Short description of the agent's purpose")
+    llm: str = Field(..., description="Key of the LLM profile used by this agent")
+
+
+class Task(BaseModel):
+    description: str = Field(..., description="Description of what the task does")
+    agent: str = Field(..., description="Name of the agent responsible for the task")
+
+
+class Team(BaseModel):
+    agents: List[str] = Field(..., description="List of agent names that compose the team")
+
+
+class SystemConfig(BaseModel):
+    llm_profiles: Dict[str, LLMProfile]
+    agents: Dict[str, Agent]
+    tasks: Dict[str, Task]
+    teams: Dict[str, Team]
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "SystemConfig":
+        """Parse a raw dict (e.g. loaded from YAML) into a SystemConfig."""
+        return cls(**data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pydantic>=2.0
+PyYAML

--- a/system_config.yaml
+++ b/system_config.yaml
@@ -1,0 +1,17 @@
+llm_profiles:
+  default:
+    provider: gemini
+    model: gemini-pro
+    temperature: 0.7
+agents:
+  researcher:
+    description: "General knowledge assistant"
+    llm: default
+tasks:
+  answer_question:
+    description: "Answer user questions"
+    agent: researcher
+teams:
+  default:
+    agents:
+      - researcher

--- a/validate_config.py
+++ b/validate_config.py
@@ -1,0 +1,25 @@
+import sys
+import yaml
+from pydantic import ValidationError
+
+from config_models import SystemConfig
+
+
+def main(path: str) -> int:
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    try:
+        SystemConfig.from_dict(data)
+    except ValidationError as e:
+        print("Config inválido:")
+        print(e)
+        return 1
+    print("Config válido!")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Uso: python validate_config.py <caminho_para_config.yaml>")
+        sys.exit(1)
+    sys.exit(main(sys.argv[1]))


### PR DESCRIPTION
## Summary
- define Pydantic models for system configuration
- add CLI validator for YAML configs
- provide sample `system_config.yaml` and basic tech debt log

## Testing
- `pip install -r requirements.txt`
- `python validate_config.py system_config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_688eb94415e88321b7831c8ac1f4c7f7