### PR TITLE
feat: add system config validator

### DIFF
--- a/src/core/config_validator.py
+++ b/src/core/config_validator.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import ValidationError
+from pydantic_core import ErrorDetails
+
+from config_models import SystemConfig
+
+
+class ConfigValidator:
+    """Validate cross references in a SystemConfig instance."""
+
+    def __init__(self, config: SystemConfig) -> None:
+        self._config = config
+
+    def validate(self) -> None:
+        """Validate configuration, raising ValidationError on issues."""
+        errors: List[ErrorDetails] = []
+
+        for agent_name, agent in self._config.agents.items():
+            if agent.llm not in self._config.llm_profiles:
+                msg = f"Unknown llm profile '{agent.llm}' for agent '{agent_name}'"
+                errors.append(
+                    {
+                        "type": "value_error",
+                        "loc": ("agents", agent_name, "llm"),
+                        "msg": msg,
+                        "input": agent.llm,
+                        "ctx": {"error": msg},
+                    }
+                )
+
+        for task_name, task in self._config.tasks.items():
+            if task.agent not in self._config.agents:
+                msg = f"Unknown agent '{task.agent}' for task '{task_name}'"
+                errors.append(
+                    {
+                        "type": "value_error",
+                        "loc": ("tasks", task_name, "agent"),
+                        "msg": msg,
+                        "input": task.agent,
+                        "ctx": {"error": msg},
+                    }
+                )
+
+        for team_name, team in self._config.teams.items():
+            for member in team.agents:
+                if member not in self._config.agents:
+                    msg = f"Team '{team_name}' references unknown agent '{member}'"
+                    errors.append(
+                        {
+                            "type": "value_error",
+                            "loc": ("teams", team_name, "agents"),
+                            "msg": msg,
+                            "input": member,
+                            "ctx": {"error": msg},
+                        }
+                    )
+
+        if errors:
+            raise ValidationError.from_exception_data("SystemConfig", errors)

--- a/tests/unit/test_config_validator.py
+++ b/tests/unit/test_config_validator.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from config_models import SystemConfig
+from src.core.config_validator import ConfigValidator
+
+
+def load_config(path: str) -> SystemConfig:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    return SystemConfig.from_dict(data)
+
+
+def test_validate_valid_config() -> None:
+    config = load_config("system_config.yaml")
+    validator = ConfigValidator(config)
+    validator.validate()  # should not raise
+
+
+def test_validate_invalid_references() -> None:
+    data = {
+        "llm_profiles": {"default": {"provider": "gemini", "model": "gemini-pro"}},
+        "agents": {"researcher": {"description": "desc", "llm": "missing"}},
+        "tasks": {
+            "t": {"description": "desc", "agent": "ghost"}
+        },
+        "teams": {"default": {"agents": ["ghost"]}},
+    }
+    config = SystemConfig.from_dict(data)
+    validator = ConfigValidator(config)
+    with pytest.raises(ValidationError) as exc:
+        validator.validate()
+    message = str(exc.value)
+    assert "missing" in message
+    assert "ghost" in message


### PR DESCRIPTION
## Summary
- add ConfigValidator to ensure SystemConfig references are consistent
- cover valid and invalid configuration scenarios with unit tests

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688f4fd59e448321b483a58ca340d4db