### PR TITLE
Add extra field validation to config models

### DIFF
--- a/config_models.py
+++ b/config_models.py
@@ -12,19 +12,27 @@ class LLMProfile(BaseModel):
         0.0, ge=0.0, le=1.0, description="Sampling temperature for the model"
     )
 
+    model_config = {"extra": "forbid"}
+
 
 class Agent(BaseModel):
     description: str = Field(..., description="Short description of the agent's purpose")
     llm: str = Field(..., description="Key of the LLM profile used by this agent")
+
+    model_config = {"extra": "forbid"}
 
 
 class Task(BaseModel):
     description: str = Field(..., description="Description of what the task does")
     agent: str = Field(..., description="Name of the agent responsible for the task")
 
+    model_config = {"extra": "forbid"}
+
 
 class Team(BaseModel):
     agents: List[str] = Field(..., description="List of agent names that compose the team")
+
+    model_config = {"extra": "forbid"}
 
 
 class SystemConfig(BaseModel):
@@ -32,6 +40,8 @@ class SystemConfig(BaseModel):
     agents: Dict[str, Agent]
     tasks: Dict[str, Task]
     teams: Dict[str, Team]
+
+    model_config = {"extra": "forbid"}
 
     @classmethod
     def from_dict(cls, data: Dict) -> "SystemConfig":


### PR DESCRIPTION
## Summary
- forbid unknown fields in LLMProfile, Agent, Task, Team, and SystemConfig models

## Testing
- `python scripts/validate_config.py system_config.yaml` *(fails: No such file or directory)*
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688f529949148321846630fa5a7405ed