### PR TITLE
refactor: make temperature mandatory float

### DIFF
--- a/config_models.py
+++ b/config_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from pydantic import BaseModel, Field
 
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 class LLMProfile(BaseModel):
     provider: str = Field(..., description="LLM service provider identifier")
     model: str = Field(..., description="Model name or identifier")
-    temperature: Optional[float] = Field(
+    temperature: float = Field(
         0.0, ge=0.0, le=1.0, description="Sampling temperature for the model"
     )
 


### PR DESCRIPTION
## Summary
- make `LLMProfile.temperature` a required float with default 0.0

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688f548bc42883219c5cf3e493d76228