### PR TITLE
refactor: use public pydantic APIs

### DIFF
--- a/src/core/config_validator.py
+++ b/src/core/config_validator.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Any
 
 from pydantic import ValidationError
-from pydantic_core import ErrorDetails
 
 from config_models import SystemConfig
 
@@ -16,7 +15,7 @@ class ConfigValidator:
 
     def validate(self) -> None:
         """Validate configuration, raising ValidationError on issues."""
-        errors: List[ErrorDetails] = []
+        errors: list[dict[str, Any]] = []
 
         for agent_name, agent in self._config.agents.items():
             if agent.llm not in self._config.llm_profiles:


### PR DESCRIPTION
## Summary
- avoid use of private `pydantic_core.ErrorDetails`
- rely on Pydantic `ValidationError` with standard dict error details

## Testing
- `python scripts/validate_config.py system_config.yaml` *(fails: file not found)*
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: file not found)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688f55a359288321810004d973269569