### PR TITLE
Use ConfigValidator and logging in validate_config

### DIFF
--- a/validate_config.py
+++ b/validate_config.py
@@ -1,25 +1,30 @@
+import logging
 import sys
+
 import yaml
 from pydantic import ValidationError
 
 from config_models import SystemConfig
+from src.core.config_validator import ConfigValidator
+
+logger = logging.getLogger(__name__)
 
 
 def main(path: str) -> int:
     with open(path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
     try:
-        SystemConfig.from_dict(data)
+        config = SystemConfig.from_dict(data)
+        ConfigValidator(config).validate()
     except ValidationError as e:
-        print("Config inválido:")
-        print(e)
+        logger.error("Config inválido: %s", e)
         return 1
-    print("Config válido!")
+    logger.info("Config válido!")
     return 0
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Uso: python validate_config.py <caminho_para_config.yaml>")
+        logger.error("Uso: python validate_config.py <caminho_para_config.yaml>")
         sys.exit(1)
     sys.exit(main(sys.argv[1]))


### PR DESCRIPTION
## Summary
- use ConfigValidator to cross-check parsed configuration
- switch validate_config to module-level logging

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: file not found)*
- `python -m pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_688f56a4c03883218acbbf090b30be4a