### PR TITLE
feat: add execute orchestration method

### DIFF
--- a/src/core/meta_orchestrator.py
+++ b/src/core/meta_orchestrator.py
@@ -1,4 +1,8 @@
-from .interfaces import IExecutionStrategy, UserRequest
+import logging
+
+from .interfaces import AgentResponse, IExecutionStrategy, UserRequest
+
+logger = logging.getLogger(__name__)
 
 
 class MetaOrchestrator:
@@ -11,3 +15,24 @@ class MetaOrchestrator:
     def select_strategy(self, analysis) -> IExecutionStrategy:
         """Seleciona a estratégia apropriada com base na análise."""
         raise NotImplementedError
+
+    def execute(self, request: UserRequest) -> AgentResponse:
+        """Processa a requisição do usuário e retorna a resposta do agente."""
+        logger.info("Iniciando processamento da requisição do usuário")
+
+        logger.debug("Analisando a requisição")
+        analysis = self.analyze_request(request)
+        logger.debug("Análise concluída: %s", analysis)
+
+        logger.debug("Selecionando estratégia")
+        strategy = self.select_strategy(analysis)
+        logger.debug(
+            "Estratégia selecionada: %s", strategy.__class__.__name__
+        )
+
+        logger.debug("Executando estratégia")
+        response = strategy.execute(request)
+        logger.debug("Execução concluída: %s", response)
+
+        logger.info("Processamento da requisição concluído")
+        return response


### PR DESCRIPTION
## Summary
- add execute method to MetaOrchestrator to analyze, select, and run strategies with logging

## Testing
- `python scripts/validate_config.py system_config.yaml` (fails: No such file or directory)
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` (fails: No such file or directory)
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688f66fb17e88321b8d215fe4522c621