### PR TITLE
Implement basic execution strategy

### DIFF
--- a/src/core/meta_orchestrator.py
+++ b/src/core/meta_orchestrator.py
@@ -1,20 +1,57 @@
 import logging
+from typing import Dict
 
+from ..strategies.basic_strategy import BasicStrategy
 from .interfaces import AgentResponse, IExecutionStrategy, UserRequest
 
 logger = logging.getLogger(__name__)
 
 
 class MetaOrchestrator:
-    """Orquestrador principal responsável por coordenar estratégias de execução."""
+    """Orquestrador responsável por analisar requisições e delegar estratégias.
 
-    def analyze_request(self, request: UserRequest):
-        """Analisa a requisição do usuário para extrair intenções."""
-        raise NotImplementedError
+    Atualmente registra apenas :class:`BasicStrategy`,
+    utilizada como estratégia padrão para qualquer requisição recebida.
+    """
 
-    def select_strategy(self, analysis) -> IExecutionStrategy:
-        """Seleciona a estratégia apropriada com base na análise."""
-        raise NotImplementedError
+    def __init__(self) -> None:
+        """Inicializa o orquestrador registrando as estratégias disponíveis."""
+        self.strategies: Dict[str, IExecutionStrategy] = {
+            "basic": BasicStrategy(),
+        }
+
+    def analyze_request(self, request: UserRequest) -> str:
+        """Analisa a requisição do usuário para determinar a estratégia.
+
+        A análise mínima identifica palavras-chave simples no texto da
+        requisição. Caso nenhuma palavra-chave seja encontrada, a estratégia
+        ``basic`` é utilizada como padrão.
+        """
+
+        text = request.text.lower()
+        if "basic" in text:
+            return "basic"
+        return "basic"
+
+    def select_strategy(self, analysis: str) -> IExecutionStrategy:
+        """Seleciona a estratégia apropriada com base na análise.
+
+        Args:
+            analysis: Identificador retornado por :meth:`analyze_request`.
+
+        Returns:
+            Implementação de :class:`IExecutionStrategy` associada ao
+            identificador.
+
+        Raises:
+            ValueError: Se nenhuma estratégia corresponder ao identificador
+                informado.
+        """
+
+        try:
+            return self.strategies[analysis]
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise ValueError(f"Estratégia desconhecida: {analysis}") from exc
 
     def execute(self, request: UserRequest) -> AgentResponse:
         """Processa a requisição do usuário e retorna a resposta do agente."""
@@ -26,9 +63,7 @@ class MetaOrchestrator:
 
         logger.debug("Selecionando estratégia")
         strategy = self.select_strategy(analysis)
-        logger.debug(
-            "Estratégia selecionada: %s", strategy.__class__.__name__
-        )
+        logger.debug("Estratégia selecionada: %s", strategy.__class__.__name__)
 
         logger.debug("Executando estratégia")
         response = strategy.execute(request)

--- a/src/strategies/basic_strategy.py
+++ b/src/strategies/basic_strategy.py
@@ -1,0 +1,18 @@
+import logging
+
+from ..core.interfaces import AgentResponse, IExecutionStrategy, UserRequest
+
+logger = logging.getLogger(__name__)
+
+
+class BasicStrategy:
+    """Estratégia simples de execução.
+
+    Utilizada como implementação mínima de :class:`IExecutionStrategy`.
+    """
+
+    def execute(self, request: UserRequest) -> AgentResponse:
+        """Executa a estratégia retornando uma resposta padrão."""
+        logger.info("Executando BasicStrategy")
+        return AgentResponse(text=f"Processed: {request.text}")
+

--- a/tests/test_meta_orchestrator.py
+++ b/tests/test_meta_orchestrator.py
@@ -1,0 +1,19 @@
+from src.core.interfaces import AgentResponse, UserRequest
+from src.core.meta_orchestrator import MetaOrchestrator
+from src.strategies.basic_strategy import BasicStrategy
+
+
+def test_meta_orchestrator_flow() -> None:
+    orchestrator = MetaOrchestrator()
+    request = UserRequest(text="teste básico")
+
+    analysis = orchestrator.analyze_request(request)
+    assert analysis == "basic"
+
+    strategy = orchestrator.select_strategy(analysis)
+    assert isinstance(strategy, BasicStrategy)
+
+    response = orchestrator.execute(request)
+    assert isinstance(response, AgentResponse)
+    assert "Processed" in response.text
+


### PR DESCRIPTION
## Summary
- implement request analysis and strategy selection in `MetaOrchestrator`
- add minimal `BasicStrategy` implementation
- cover orchestrator flow with unit test

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688f6c33b6e883218e75ed32ee0b2bdf