### PR TITLE
test: add basic strategy execution test

### DIFF
--- a/tests/unit/test_basic_strategy.py
+++ b/tests/unit/test_basic_strategy.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import logging
+import pytest
+
+from src.core.interfaces import AgentResponse, UserRequest
+from src.strategies.basic_strategy import BasicStrategy
+
+
+def test_basic_strategy_execute_returns_expected_response(caplog: pytest.LogCaptureFixture) -> None:
+    strategy = BasicStrategy()
+    request = UserRequest(text="example")
+
+    with caplog.at_level(logging.INFO):
+        response = strategy.execute(request)
+
+    assert isinstance(response, AgentResponse)
+    assert response.text == "Processed: example"
+    assert "Executando BasicStrategy" in caplog.text
+


### PR DESCRIPTION
## Summary
- add unit test for BasicStrategy to ensure execute returns expected AgentResponse and logs

## Testing
- `python scripts/validate_config.py system_config.yaml` *(fails: No such file or directory)*
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688f77034758832181af5544eac2c3db