### PR TITLE
feat: add research strategy to meta orchestrator

### DIFF
--- a/src/strategies/research_strategy.py
+++ b/src/strategies/research_strategy.py
@@ -1,0 +1,14 @@
+import logging
+
+from ..core.interfaces import AgentResponse, IExecutionStrategy, UserRequest
+
+logger = logging.getLogger(__name__)
+
+
+class ResearchStrategy:
+    """Estratégia que simula a pesquisa de informações."""
+
+    def execute(self, request: UserRequest) -> AgentResponse:
+        """Executa a estratégia retornando uma resposta de pesquisa."""
+        logger.info("Executando ResearchStrategy")
+        return AgentResponse(text=f"Researching: {request.text}")

--- a/tests/test_meta_orchestrator.py
+++ b/tests/test_meta_orchestrator.py
@@ -1,9 +1,10 @@
 from src.core.interfaces import AgentResponse, UserRequest
 from src.core.meta_orchestrator import MetaOrchestrator
 from src.strategies.basic_strategy import BasicStrategy
+from src.strategies.research_strategy import ResearchStrategy
 
 
-def test_meta_orchestrator_flow() -> None:
+def test_meta_orchestrator_basic_strategy() -> None:
     orchestrator = MetaOrchestrator()
     request = UserRequest(text="teste básico")
 
@@ -16,4 +17,19 @@ def test_meta_orchestrator_flow() -> None:
     response = orchestrator.execute(request)
     assert isinstance(response, AgentResponse)
     assert "Processed" in response.text
+
+
+def test_meta_orchestrator_research_strategy() -> None:
+    orchestrator = MetaOrchestrator()
+    request = UserRequest(text="please research about AI")
+
+    analysis = orchestrator.analyze_request(request)
+    assert analysis == "research"
+
+    strategy = orchestrator.select_strategy(analysis)
+    assert isinstance(strategy, ResearchStrategy)
+
+    response = orchestrator.execute(request)
+    assert isinstance(response, AgentResponse)
+    assert "Researching" in response.text
 


### PR DESCRIPTION
## Summary
- extend MetaOrchestrator to register and route to ResearchStrategy
- add ResearchStrategy implementation and tests for multiple strategies

## Testing
- `python scripts/validate_config.py system_config.yaml` *(fails: can't open file)*
- `python scripts/validate_interfaces.py` *(fails: can't open file)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688f76f589888321ae10d2e9184f0177