### PR TITLE
feat: add version to system config

### DIFF
--- a/config_models.py
+++ b/config_models.py
@@ -36,6 +36,7 @@ class Team(BaseModel):
 
 
 class SystemConfig(BaseModel):
+    version: str = Field(..., description="Configuration schema version")
     llm_profiles: Dict[str, LLMProfile]
     agents: Dict[str, Agent]
     tasks: Dict[str, Task]

--- a/system_config.yaml
+++ b/system_config.yaml
@@ -1,3 +1,4 @@
+version: "1.0"
 llm_profiles:
   default:
     provider: gemini

--- a/tests/unit/test_config_validator.py
+++ b/tests/unit/test_config_validator.py
@@ -18,10 +18,12 @@ def test_validate_valid_config() -> None:
     config = load_config("system_config.yaml")
     validator = ConfigValidator(config)
     validator.validate()  # should not raise
+    assert config.version == "1.0"
 
 
 def test_validate_invalid_references() -> None:
     data = {
+        "version": "1.0",
         "llm_profiles": {"default": {"provider": "gemini", "model": "gemini-pro"}},
         "agents": {"researcher": {"description": "desc", "llm": "missing"}},
         "tasks": {


### PR DESCRIPTION
## Summary
- track schema version via new `version` field in `SystemConfig`
- include `version: "1.0"` in `system_config.yaml`
- adjust config validator tests for the new field

## Testing
- `python scripts/validate_config.py system_config.yaml` (fails: No such file or directory)
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` (fails: No such file or directory)
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688f76df22d88321b685946b3beedf99