### PR TITLE
feat: scaffold SimpleRAG memory stub

### DIFF
--- a/AI_AGENTS_GUIDE.md
+++ b/AI_AGENTS_GUIDE.md
@@ -133,8 +133,7 @@ Meta-Orquestrador Core:
 - Próximo: aprimorar ``analyze_request`` para múltiplas estratégias
 
 ChromaDB Integration:
-- Status: 30% completo  
-- Arquivo: src/memory/simple_rag.py
+- Status: implementação inicial (stub)
 - Pendente: Pipeline de ingestão
 ```
 
@@ -216,7 +215,6 @@ DEFAULT_TIMEOUT = 30
 ```python
 # Sempre use imports absolutos
 from src.core.interfaces import IExecutionStrategy
-from src.memory.simple_rag import SimpleRAG
 
 # Evite imports circulares
 # Use typing.TYPE_CHECKING se necessário

--- a/TECH_DEBT_LOG.md
+++ b/TECH_DEBT_LOG.md
@@ -5,3 +5,9 @@ Registre aqui decisões técnicas que requerem revisões futuras ou potenciais r
 ## Entradas
 
 - *[2024-05-10]* Estrutura inicial do `system_config` definida de forma simples; poderá ser expandida para suportar hierarquias de equipes e permissões.
+
+## [2025-08-03] Stub temporário para SimpleRAG
+**Localização**: `src/memory/simple_rag.py`
+**Descrição**: Classe `SimpleRAG` criada como interface mínima, sem integração com banco vetorial ou grafo.
+**Refatoração Planejada**: Iteração futura para conectar ChromaDB e Neo4j.
+**Responsável**: @arquiteto_principal

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -1,0 +1,5 @@
+"""Memory module exposing memory-related implementations."""
+
+from .simple_rag import SimpleRAG
+
+__all__ = ["SimpleRAG"]

--- a/src/memory/simple_rag.py
+++ b/src/memory/simple_rag.py
@@ -1,0 +1,55 @@
+"""Stub module for a simple Retrieval-Augmented Generation (RAG) system.
+
+This module defines the minimal interface for future memory integration.
+It will initially support ChromaDB for vector storage and retrieval, with
+plans to incorporate Neo4j for graph-based relationships in later
+iterations.
+"""
+
+from typing import List
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class SimpleRAG:
+    """Placeholder RAG implementation.
+
+    Methods defined here outline the expected API for the memory subsystem.
+    Concrete functionality will be added incrementally as integrations are
+    completed.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the RAG system.
+
+        Future versions may configure connections to vector stores
+        and graph databases during initialization.
+        """
+        logger.debug("SimpleRAG initialized (stub)")
+
+    def add_documents(self, texts: List[str]) -> None:
+        """Ingest a batch of documents into the memory store.
+
+        Args:
+            texts: Raw text documents to embed and persist.
+
+        Raises:
+            NotImplementedError: This method is a stub.
+        """
+        raise NotImplementedError("Document ingestion not implemented yet")
+
+    def query(self, question: str, top_k: int = 5) -> List[str]:
+        """Retrieve relevant documents for a given question.
+
+        Args:
+            question: Natural language query.
+            top_k: Number of results to return.
+
+        Returns:
+            Placeholder list of document snippets.
+
+        Raises:
+            NotImplementedError: This method is a stub.
+        """
+        raise NotImplementedError("Query mechanism not implemented yet")


### PR DESCRIPTION
## Summary
- add SimpleRAG stub with minimal API for future RAG integration
- document stub status and remove outdated references
- log technical debt for pending memory implementation

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_688f976cf8c083218a6c9b42e3af204e