### PR TITLE
test: add ResearchStrategy unit test

### DIFF
--- a/tests/unit/test_research_strategy.py
+++ b/tests/unit/test_research_strategy.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import logging
+import pytest
+
+from src.core.interfaces import AgentResponse, UserRequest
+from src.strategies.research_strategy import ResearchStrategy
+
+
+def test_research_strategy_execute_returns_expected_response(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    strategy = ResearchStrategy()
+    request = UserRequest(text="example research")
+
+    with caplog.at_level(logging.INFO):
+        response = strategy.execute(request)
+
+    assert isinstance(response, AgentResponse)
+    assert response.text == "Researching: example research"
+    assert "Executando ResearchStrategy" in caplog.text
+


### PR DESCRIPTION
## Summary
- add unit test covering ResearchStrategy execute response and logging

## Testing
- `python scripts/validate_config.py system_config.yaml` *(fails: file or directory not found)*
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: file or directory not found)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688f9b48932083219bdaa4d516ec6ef3