### PR TITLE
Add logging setup to config validation script

### DIFF
--- a/AI_AGENTS_GUIDE.md
+++ b/AI_AGENTS_GUIDE.md
@@ -589,7 +589,7 @@ class NovaStrategy(IExecutionStrategy):
 
 ### Scripts Úteis
 
-- `validate_config.py` - Validação de configuração
+- `validate_config.py` - Validação de configuração. Execute `python validate_config.py system_config.yaml` para verificar o arquivo de configuração. O script exibirá `INFO: Configuração validada com sucesso.` quando não houver problemas ou `ERROR: Configuração inválida: ...` detalhando o erro encontrado.
 - `python -m pytest` - Execução de testes
 
 -----

--- a/validate_config.py
+++ b/validate_config.py
@@ -7,19 +7,29 @@ from pydantic import ValidationError
 from config_models import SystemConfig
 from src.core.config_validator import ConfigValidator
 
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
 
 def main(path: str) -> int:
-    with open(path, "r", encoding="utf-8") as f:
-        data = yaml.safe_load(f)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError:
+        logger.error("Arquivo não encontrado: %s", path)
+        return 1
+    except yaml.YAMLError as e:
+        logger.error("Erro ao ler YAML: %s", e)
+        return 1
+
     try:
         config = SystemConfig.from_dict(data)
         ConfigValidator(config).validate()
     except ValidationError as e:
-        logger.error("Config inválido: %s", e)
+        logger.error("Configuração inválida: %s", e)
         return 1
-    logger.info("Config válido!")
+
+    logger.info("Configuração validada com sucesso.")
     return 0
 
 


### PR DESCRIPTION
## Summary
- configure logging for `validate_config.py` to output informative success and error messages
- document how to run the configuration validator in AI_AGENTS_GUIDE

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688f991a69d083218c023cc3cca98038