### PR TITLE
Improve configuration validation logging

### DIFF
--- a/AI_AGENTS_GUIDE.md
+++ b/AI_AGENTS_GUIDE.md
@@ -587,7 +587,10 @@ class NovaStrategy(IExecutionStrategy):
 
 ### Scripts Úteis
 
-- `validate_config.py` - Validação de configuração. Execute `python validate_config.py system_config.yaml` para verificar o arquivo de configuração. O script exibirá `INFO: Configuração validada com sucesso.` quando não houver problemas ou `ERROR: Configuração inválida: ...` detalhando o erro encontrado.
+- `validate_config.py` - Valida arquivos de configuração YAML. Execute
+  `python validate_config.py system_config.yaml` para checar o arquivo. O
+  script escreve no console `INFO: Configuração validada com sucesso.` quando
+  tudo estiver correto ou `ERROR: ...` detalhando qualquer problema.
 - `python -m pytest` - Execução de testes
 
 -----

--- a/validate_config.py
+++ b/validate_config.py
@@ -7,11 +7,17 @@ from pydantic import ValidationError
 from config_models import SystemConfig
 from src.core.config_validator import ConfigValidator
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s: %(message)s",
+    stream=sys.stdout,
+)
 logger = logging.getLogger(__name__)
 
 
 def main(path: str) -> int:
+    logger.info("Validando arquivo de configuração: %s", path)
+
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f)
@@ -27,6 +33,9 @@ def main(path: str) -> int:
         ConfigValidator(config).validate()
     except ValidationError as e:
         logger.error("Configuração inválida: %s", e)
+        return 1
+    except Exception as e:  # pragma: no cover - salvaguarda
+        logger.error("Falha inesperada na validação: %s", e)
         return 1
 
     logger.info("Configuração validada com sucesso.")


### PR DESCRIPTION
## Summary
- configure logging to output config validation status to the console
- document validate_config usage in AI_AGENTS_GUIDE

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: can't open file)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688fa34286708321aca294db9fb462dc