### PR TITLE
Specify minimum stable versions for key dependencies

### DIFF
--- a/TECH_DEBT_LOG.md
+++ b/TECH_DEBT_LOG.md
@@ -6,3 +6,9 @@ Registre aqui decisões técnicas que requerem revisões futuras ou potenciais r
 
 - *[2024-05-10]* Estrutura inicial do `system_config` definida de forma simples; poderá ser expandida para suportar hierarquias de equipes e permissões.
 
+## [2025-08-03] Versionamento mínimo de dependências críticas
+**Localização**: `requirements.txt`
+**Descrição**: Definidas versões mínimas estáveis para Pydantic (>=2.7,<3) e PyYAML (>=6.0,<7) visando garantir compatibilidade e previsibilidade.
+**Refatoração Planejada**: Reavaliar limites ao surgir nova versão principal das dependências.
+**Responsável**: @ai_assistant
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pydantic>=2.0
-PyYAML
+pydantic>=2.7,<3
+PyYAML>=6.0,<7


### PR DESCRIPTION
## Summary
- pin Pydantic and PyYAML to stable minimum versions
- log dependency versioning rationale in TECH_DEBT_LOG

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688faa7f749083218f1d5bc5a3fa446b