### PR TITLE
docs: add project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Agente Pessoal – Sistema Multi‑Agente
+
+Este repositório implementa um **sistema multi‑agente de IA**. O Meta‑Orquestrador coordena agentes especializados com memória de longo prazo e estratégias de execução configuráveis. A configuração principal fica em `system_config.yaml`.
+
+## Estrutura de diretórios
+
+```
+.
+├── src/
+│   ├── core/        # Meta‑Orquestrador e abstrações
+│   ├── strategies/  # Estratégias de execução
+│   ├── agents/      # Agentes especializados
+│   ├── memory/      # Integração RAG
+│   ├── tools/       # Integrações externas
+│   └── adapters/    # Interfaces (Telegram, etc.)
+├── tests/           # Testes unitários e de integração
+├── system_config.yaml
+├── validate_config.py
+└── requirements.txt
+```
+
+## Instalação
+
+```bash
+pip install -r requirements.txt
+```
+
+## Validação básica
+
+```bash
+python validate_config.py system_config.yaml
+pytest -v
+```
+
+## Documentos relacionados
+
+- [Plano_de_arquitetura.md](Plano_de_arquitetura.md)
+- [Plano_de_execucao.md](Plano_de_execucao.md)
+- [AGENTS.md](AGENTS.md)
+- [AI_AGENTS_GUIDE.md](AI_AGENTS_GUIDE.md)
+- [TECH_DEBT_LOG.md](TECH_DEBT_LOG.md)
+
+Esses arquivos contêm decisões de arquitetura, padrões de desenvolvimento e histórico de débito técnico.


### PR DESCRIPTION
## Summary
- document the multi-agent system with overview, directory layout, and validation steps
- link to architecture, execution and guideline documents

## Testing
- `python validate_config.py system_config.yaml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_688faa7afc8c8321a99bec7fd487bcae