### PR TITLE
Add sample agent with basic logging and tests

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,3 @@
+from .sample_agent import SampleAgent
+
+__all__ = ["SampleAgent"]

--- a/src/agents/sample_agent.py
+++ b/src/agents/sample_agent.py
@@ -1,0 +1,16 @@
+import logging
+
+from src.core.interfaces import AgentResponse, UserRequest
+
+logger = logging.getLogger(__name__)
+
+
+class SampleAgent:
+    """Agente de exemplo que ecoa o texto do usuário."""
+
+    def run(self, request: UserRequest) -> AgentResponse:
+        """Processa a requisição do usuário e retorna uma resposta."""
+        logger.info("SampleAgent received request: %s", request.text)
+        response = AgentResponse(text=f"Echo: {request.text}")
+        logger.info("SampleAgent response: %s", response.text)
+        return response

--- a/tests/unit/test_sample_agent.py
+++ b/tests/unit/test_sample_agent.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import logging
+import pytest
+
+from src.core.interfaces import AgentResponse, UserRequest
+from src.agents.sample_agent import SampleAgent
+
+
+def test_sample_agent_run_returns_expected_response(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    agent = SampleAgent()
+    request = UserRequest(text="hello")
+
+    with caplog.at_level(logging.INFO):
+        response = agent.run(request)
+
+    assert isinstance(response, AgentResponse)
+    assert response.text == "Echo: hello"
+    assert "SampleAgent received request: hello" in caplog.text
+    assert "SampleAgent response: Echo: hello" in caplog.text


### PR DESCRIPTION
## Summary
- add `SampleAgent` that echoes user requests and logs activity
- export `SampleAgent` in agents package
- cover new agent with unit test

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688faa75c1cc8321acbfbed025ccaf75