### PR TITLE
feat: centralize logging configuration

### DIFF
--- a/src/core/meta_orchestrator.py
+++ b/src/core/meta_orchestrator.py
@@ -1,11 +1,11 @@
-import logging
 from typing import Dict
 
 from ..strategies.basic_strategy import BasicStrategy
 from ..strategies.research_strategy import ResearchStrategy
 from .interfaces import AgentResponse, IExecutionStrategy, UserRequest
+from ..utils.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class MetaOrchestrator:

--- a/src/strategies/basic_strategy.py
+++ b/src/strategies/basic_strategy.py
@@ -1,8 +1,7 @@
-import logging
-
 from ..core.interfaces import AgentResponse, IExecutionStrategy, UserRequest
+from ..utils.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class BasicStrategy:

--- a/src/strategies/research_strategy.py
+++ b/src/strategies/research_strategy.py
@@ -1,8 +1,7 @@
-import logging
-
 from ..core.interfaces import AgentResponse, IExecutionStrategy, UserRequest
+from ..utils.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ResearchStrategy:

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,3 @@
+from .logging import get_logger
+
+__all__ = ["get_logger"]

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -1,0 +1,38 @@
+import logging
+import sys
+from typing import Optional
+
+LOG_FORMAT = "%(levelname)s - %(name)s - %(message)s"
+
+_configured = False
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure global logging once.
+
+    Args:
+        level: Minimum logging level.
+    """
+    global _configured
+    if _configured:
+        return
+
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter(LOG_FORMAT)
+    handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    root_logger.addHandler(handler)
+
+    _configured = True
+
+
+def get_logger(name: str, level: Optional[int] = None) -> logging.Logger:
+    """Return a logger configured with the global settings.
+
+    Args:
+        name: Logger name, typically ``__name__`` of the caller.
+        level: Optional level override.
+    """
+    configure_logging(level if level is not None else logging.INFO)
+    return logging.getLogger(name)

--- a/tests/test_meta_orchestrator.py
+++ b/tests/test_meta_orchestrator.py
@@ -1,22 +1,36 @@
+import logging
+from typing import Iterable
+import pytest
+
 from src.core.interfaces import AgentResponse, UserRequest
 from src.core.meta_orchestrator import MetaOrchestrator
 from src.strategies.basic_strategy import BasicStrategy
 from src.strategies.research_strategy import ResearchStrategy
+from src.utils.logging import LOG_FORMAT
 
 
-def test_meta_orchestrator_basic_strategy() -> None:
+def _get_configured_handler(handlers: Iterable[logging.Handler]) -> logging.Handler:
+    return next(h for h in handlers if getattr(h.formatter, "_fmt", "") == LOG_FORMAT)
+
+
+def test_meta_orchestrator_basic_strategy(caplog: pytest.LogCaptureFixture) -> None:
     orchestrator = MetaOrchestrator()
     request = UserRequest(text="teste básico")
 
-    analysis = orchestrator.analyze_request(request)
+    with caplog.at_level(logging.INFO):
+        analysis = orchestrator.analyze_request(request)
+        strategy = orchestrator.select_strategy(analysis)
+        response = orchestrator.execute(request)
+
     assert analysis == "basic"
-
-    strategy = orchestrator.select_strategy(analysis)
     assert isinstance(strategy, BasicStrategy)
-
-    response = orchestrator.execute(request)
     assert isinstance(response, AgentResponse)
     assert "Processed" in response.text
+
+    handler = _get_configured_handler(logging.getLogger().handlers)
+    record = next(r for r in caplog.records if r.message == "Processamento da requisição concluído")
+    formatted = handler.format(record)
+    assert formatted == "INFO - src.core.meta_orchestrator - Processamento da requisição concluído"
 
 
 def test_meta_orchestrator_research_strategy() -> None:

--- a/tests/unit/test_basic_strategy.py
+++ b/tests/unit/test_basic_strategy.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 import logging
+from typing import Iterable
 import pytest
 
 from src.core.interfaces import AgentResponse, UserRequest
 from src.strategies.basic_strategy import BasicStrategy
+from src.utils.logging import LOG_FORMAT
+
+
+def _get_configured_handler(handlers: Iterable[logging.Handler]) -> logging.Handler:
+    return next(h for h in handlers if getattr(h.formatter, "_fmt", "") == LOG_FORMAT)
 
 
 def test_basic_strategy_execute_returns_expected_response(caplog: pytest.LogCaptureFixture) -> None:
@@ -16,5 +22,9 @@ def test_basic_strategy_execute_returns_expected_response(caplog: pytest.LogCapt
 
     assert isinstance(response, AgentResponse)
     assert response.text == "Processed: example"
-    assert "Executando BasicStrategy" in caplog.text
+
+    handler = _get_configured_handler(logging.getLogger().handlers)
+    record = next(r for r in caplog.records if r.message == "Executando BasicStrategy")
+    formatted = handler.format(record)
+    assert formatted == "INFO - src.strategies.basic_strategy - Executando BasicStrategy"
 

--- a/tests/unit/test_research_strategy.py
+++ b/tests/unit/test_research_strategy.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 import logging
+from typing import Iterable
 import pytest
 
 from src.core.interfaces import AgentResponse, UserRequest
 from src.strategies.research_strategy import ResearchStrategy
+from src.utils.logging import LOG_FORMAT
+
+
+def _get_configured_handler(handlers: Iterable[logging.Handler]) -> logging.Handler:
+    return next(h for h in handlers if getattr(h.formatter, "_fmt", "") == LOG_FORMAT)
 
 
 def test_research_strategy_execute_returns_expected_response(
@@ -18,5 +24,9 @@ def test_research_strategy_execute_returns_expected_response(
 
     assert isinstance(response, AgentResponse)
     assert response.text == "Researching: example research"
-    assert "Executando ResearchStrategy" in caplog.text
+
+    handler = _get_configured_handler(logging.getLogger().handlers)
+    record = next(r for r in caplog.records if r.message == "Executando ResearchStrategy")
+    formatted = handler.format(record)
+    assert formatted == "INFO - src.strategies.research_strategy - Executando ResearchStrategy"
 

--- a/validate_config.py
+++ b/validate_config.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 
 import yaml
@@ -6,13 +5,9 @@ from pydantic import ValidationError
 
 from config_models import SystemConfig
 from src.core.config_validator import ConfigValidator
+from src.utils.logging import get_logger
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(levelname)s: %(message)s",
-    stream=sys.stdout,
-)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def main(path: str) -> int:


### PR DESCRIPTION
## Summary
- centralize logging in a shared utility and apply across core modules
- add log-format assertions to strategy and orchestrator tests

## Testing
- `python validate_config.py system_config.yaml`
- `PYTHONPATH=. pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688faa70ccec83219a84e59b22d094ff