### PR TITLE
feat: validate system version format

### DIFF
--- a/config_models.py
+++ b/config_models.py
@@ -36,7 +36,9 @@ class Team(BaseModel):
 
 
 class SystemConfig(BaseModel):
-    version: str = Field(..., description="Configuration schema version")
+    version: str = Field(
+        ..., description="Configuration schema version", pattern=r"^\d+\.\d+$"
+    )
     llm_profiles: Dict[str, LLMProfile]
     agents: Dict[str, Agent]
     tasks: Dict[str, Task]

--- a/tests/unit/test_version_validation.py
+++ b/tests/unit/test_version_validation.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from config_models import SystemConfig
+from validate_config import main as validate_main
+
+
+def _load_base_config() -> dict:
+    with open("system_config.yaml", "r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def test_system_config_accepts_valid_version() -> None:
+    data = _load_base_config()
+    data["version"] = "2.1"
+    config = SystemConfig.from_dict(data)
+    assert config.version == "2.1"
+
+
+def test_system_config_rejects_invalid_version() -> None:
+    data = _load_base_config()
+    data["version"] = "2"
+    with pytest.raises(ValidationError):
+        SystemConfig.from_dict(data)
+
+
+def test_validate_config_reports_invalid_version(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    data = _load_base_config()
+    data["version"] = "2"
+    cfg_path = tmp_path / "config.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(data, fh)
+
+    caplog.set_level(logging.ERROR)
+    result = validate_main(str(cfg_path))
+    assert result == 1
+    assert "Versão inválida" in caplog.text

--- a/validate_config.py
+++ b/validate_config.py
@@ -32,6 +32,12 @@ def main(path: str) -> int:
         config = SystemConfig.from_dict(data)
         ConfigValidator(config).validate()
     except ValidationError as e:
+        for err in e.errors():
+            if err.get("loc") == ("version",) and err.get("type") == "string_pattern_mismatch":
+                logger.error(
+                    "Versão inválida '%s': esperado formato 'X.Y'", err.get("input")
+                )
+                return 1
         logger.error("Configuração inválida: %s", e)
         return 1
     except Exception as e:  # pragma: no cover - salvaguarda


### PR DESCRIPTION
## Summary
- enforce semantic version pattern on SystemConfig.version
- show clear error when version doesn't match expected pattern
- cover valid and invalid versions in tests

## Testing
- `python validate_config.py system_config.yaml`
- `PYTHONPATH=. pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_688faa6ab8c083218679444cfb2f44eb