### PR TITLE
Expand keyword mapping with multilingual support

### DIFF
--- a/config_models.py
+++ b/config_models.py
@@ -41,6 +41,10 @@ class SystemConfig(BaseModel):
     agents: Dict[str, Agent]
     tasks: Dict[str, Task]
     teams: Dict[str, Team]
+    keyword_map: Dict[str, List[str]] = Field(
+        default_factory=dict,
+        description="Mapping of strategy names to additional keywords",
+    )
 
     model_config = {"extra": "forbid"}
 

--- a/system_config.yaml
+++ b/system_config.yaml
@@ -16,3 +16,15 @@ teams:
   default:
     agents:
       - researcher
+keyword_map:
+  research:
+    - pesquisa
+    - investigacion
+    - investigación
+    - recherche
+    - ricerca
+  basic:
+    - basico
+    - básico
+    - basique
+    - semplice

--- a/tests/test_meta_orchestrator.py
+++ b/tests/test_meta_orchestrator.py
@@ -1,3 +1,6 @@
+import yaml
+
+from config_models import SystemConfig
 from src.core.interfaces import AgentResponse, UserRequest
 from src.core.meta_orchestrator import MetaOrchestrator
 from src.strategies.basic_strategy import BasicStrategy
@@ -32,4 +35,27 @@ def test_meta_orchestrator_research_strategy() -> None:
     response = orchestrator.execute(request)
     assert isinstance(response, AgentResponse)
     assert "Researching" in response.text
+
+
+def test_meta_orchestrator_research_synonyms_spanish_french() -> None:
+    orchestrator = MetaOrchestrator()
+
+    request_es = UserRequest(text="Necesito investigación sobre IA")
+    assert orchestrator.analyze_request(request_es) == "research"
+
+    request_fr = UserRequest(text="Peux-tu faire une recherche sur l'IA?")
+    assert orchestrator.analyze_request(request_fr) == "research"
+
+
+def test_meta_orchestrator_custom_keywords_from_config() -> None:
+    with open("system_config.yaml", "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    config = SystemConfig.from_dict(data)
+
+    orchestrator_default = MetaOrchestrator()
+    request_it = UserRequest(text="Poderia fazer uma ricerca sobre IA?")
+    assert orchestrator_default.analyze_request(request_it) == "basic"
+
+    orchestrator_config = MetaOrchestrator(keyword_map=config.keyword_map)
+    assert orchestrator_config.analyze_request(request_it) == "research"
 


### PR DESCRIPTION
## Summary
- add multilingual default keyword map and support config-driven keyword extensions
- expose keyword_map in `SystemConfig` and example config in `system_config.yaml`
- test keyword detection across Spanish, French, and config-driven Italian terms

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688faa63b5f88321a00aacfc3f757be1