### PR TITLE
test: add system config round-trip serialization

### DIFF
--- a/tests/unit/test_system_config_round_trip.py
+++ b/tests/unit/test_system_config_round_trip.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import yaml
+
+from config_models import SystemConfig
+
+
+def test_system_config_round_trip(tmp_path) -> None:
+    with open("system_config.yaml", "r", encoding="utf-8") as fh:
+        original_data = yaml.safe_load(fh)
+    original_config = SystemConfig.from_dict(original_data)
+
+    dumped_data = original_config.model_dump()
+
+    temp_file = tmp_path / "temp_config.yaml"
+    with temp_file.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(dumped_data, fh, sort_keys=False)
+
+    with temp_file.open("r", encoding="utf-8") as fh:
+        reloaded_data = yaml.safe_load(fh)
+    reloaded_config = SystemConfig.from_dict(reloaded_data)
+
+    # ensure no extra fields were introduced
+    assert reloaded_data == dumped_data
+    # ensure the reloaded object matches the original
+    assert reloaded_config == original_config


### PR DESCRIPTION
## Summary
- test system_config.yaml round-trip serialization to ensure no extra fields

## Testing
- `python scripts/validate_config.py system_config.yaml` *(fails: No such file or directory)*
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_688faa5ffcac8321a5a33202b26d68d5