### PR TITLE
Add duplicate validation for agents and tasks

### DIFF
--- a/src/core/config_validator.py
+++ b/src/core/config_validator.py
@@ -17,6 +17,40 @@ class ConfigValidator:
         """Validate configuration, raising ValidationError on issues."""
         errors: list[dict[str, Any]] = []
 
+        seen_agents: set[str] = set()
+        for agent_name in self._config.agents:
+            normalized = agent_name.lower()
+            if normalized in seen_agents:
+                msg = f"Duplicate agent entry '{agent_name}'"
+                errors.append(
+                    {
+                        "type": "value_error",
+                        "loc": ("agents", agent_name),
+                        "msg": msg,
+                        "input": agent_name,
+                        "ctx": {"error": msg},
+                    }
+                )
+            else:
+                seen_agents.add(normalized)
+
+        seen_tasks: set[str] = set()
+        for task_name in self._config.tasks:
+            normalized = task_name.lower()
+            if normalized in seen_tasks:
+                msg = f"Duplicate task entry '{task_name}'"
+                errors.append(
+                    {
+                        "type": "value_error",
+                        "loc": ("tasks", task_name),
+                        "msg": msg,
+                        "input": task_name,
+                        "ctx": {"error": msg},
+                    }
+                )
+            else:
+                seen_tasks.add(normalized)
+
         for agent_name, agent in self._config.agents.items():
             if agent.llm not in self._config.llm_profiles:
                 msg = f"Unknown llm profile '{agent.llm}' for agent '{agent_name}'"

--- a/tests/unit/test_config_validator.py
+++ b/tests/unit/test_config_validator.py
@@ -38,3 +38,26 @@ def test_validate_invalid_references() -> None:
     message = str(exc.value)
     assert "missing" in message
     assert "ghost" in message
+
+
+def test_validate_duplicate_entries() -> None:
+    data = {
+        "version": "1.0",
+        "llm_profiles": {"default": {"provider": "gemini", "model": "gemini-pro"}},
+        "agents": {
+            "researcher": {"description": "desc", "llm": "default"},
+            "Researcher": {"description": "desc", "llm": "default"},
+        },
+        "tasks": {
+            "answer": {"description": "desc", "agent": "researcher"},
+            "Answer": {"description": "desc", "agent": "researcher"},
+        },
+        "teams": {"default": {"agents": ["researcher"]}},
+    }
+    config = SystemConfig.from_dict(data)
+    validator = ConfigValidator(config)
+    with pytest.raises(ValidationError) as exc:
+        validator.validate()
+    message = str(exc.value)
+    assert "Duplicate agent entry" in message
+    assert "Duplicate task entry" in message


### PR DESCRIPTION
## Summary
- detect duplicated names for agents and tasks in `ConfigValidator`
- cover duplicate cases with unit test

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688faa5b9bfc83219581ede59dbb09b6