### PR TITLE
docs: improve docstrings for strategies and orchestrator

### DIFF
--- a/src/core/meta_orchestrator.py
+++ b/src/core/meta_orchestrator.py
@@ -1,3 +1,5 @@
+"""Orquestrador central que coordena múltiplas estratégias de execução."""
+
 import logging
 from typing import Dict
 
@@ -24,8 +26,13 @@ class MetaOrchestrator:
         A análise mínima identifica palavras-chave simples no texto da
         requisição. Caso nenhuma palavra-chave seja encontrada, a estratégia
         ``basic`` é utilizada como padrão.
-        """
 
+        Args:
+            request: Requisição enviada pelo usuário.
+
+        Returns:
+            Identificador da estratégia a ser utilizada.
+        """
         text = request.text.lower()
         if any(keyword in text for keyword in ("research", "pesquisa")):
             return "research"
@@ -41,13 +48,10 @@ class MetaOrchestrator:
 
         Returns:
             Implementação de :class:`IExecutionStrategy` associada ao
-            identificador.
-
-        Raises:
-            ValueError: Se nenhuma estratégia corresponder ao identificador
-                informado.
+            identificador. Se nenhuma estratégia corresponder ao
+            identificador informado, a estratégia ``basic`` é utilizada e um
+            aviso é registrado no log.
         """
-
         try:
             return self.strategies[analysis]
         except KeyError:
@@ -55,7 +59,14 @@ class MetaOrchestrator:
             return self.strategies["basic"]
 
     def execute(self, request: UserRequest) -> AgentResponse:
-        """Processa a requisição do usuário e retorna a resposta do agente."""
+        """Processa a requisição do usuário e retorna a resposta do agente.
+
+        Args:
+            request: Requisição do usuário a ser processada.
+
+        Returns:
+            Resposta do agente gerada pela estratégia selecionada.
+        """
         logger.info("Iniciando processamento da requisição do usuário")
 
         logger.debug("Analisando a requisição")

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,0 +1,1 @@
+"""Pacote que reúne as estratégias de execução disponíveis."""

--- a/src/strategies/basic_strategy.py
+++ b/src/strategies/basic_strategy.py
@@ -1,3 +1,5 @@
+"""Estratégias básicas de execução."""
+
 import logging
 
 from ..core.interfaces import AgentResponse, IExecutionStrategy, UserRequest
@@ -12,7 +14,14 @@ class BasicStrategy:
     """
 
     def execute(self, request: UserRequest) -> AgentResponse:
-        """Executa a estratégia retornando uma resposta padrão."""
+        """Executa a estratégia retornando uma resposta padrão.
+
+        Args:
+            request: Requisição do usuário que será processada.
+
+        Returns:
+            Resposta gerada contendo o texto processado.
+        """
         logger.info("Executando BasicStrategy")
         return AgentResponse(text=f"Processed: {request.text}")
 

--- a/src/strategies/research_strategy.py
+++ b/src/strategies/research_strategy.py
@@ -1,3 +1,5 @@
+"""Estratégias de pesquisa de informações."""
+
 import logging
 
 from ..core.interfaces import AgentResponse, IExecutionStrategy, UserRequest
@@ -9,6 +11,13 @@ class ResearchStrategy:
     """Estratégia que simula a pesquisa de informações."""
 
     def execute(self, request: UserRequest) -> AgentResponse:
-        """Executa a estratégia retornando uma resposta de pesquisa."""
+        """Executa a estratégia retornando uma resposta de pesquisa.
+
+        Args:
+            request: Requisição do usuário com o tema da pesquisa.
+
+        Returns:
+            Resposta contendo o texto que simula o resultado da pesquisa.
+        """
         logger.info("Executando ResearchStrategy")
         return AgentResponse(text=f"Researching: {request.text}")


### PR DESCRIPTION
## Summary
- document meta-orchestrator methods with parameter and return details
- expand docstrings for basic and research strategies and add package/module docs

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`
- `pydocstyle src/core/meta_orchestrator.py src/strategies`


------
https://chatgpt.com/codex/tasks/task_e_688faa534aec8321902a472107abd8a6