### PR TITLE
Enforce positive config values

### DIFF
--- a/config_models.py
+++ b/config_models.py
@@ -9,7 +9,7 @@ class LLMProfile(BaseModel):
     provider: str = Field(..., description="LLM service provider identifier")
     model: str = Field(..., description="Model name or identifier")
     temperature: float = Field(
-        0.0, ge=0.0, le=1.0, description="Sampling temperature for the model"
+        0.1, gt=0.0, le=1.0, description="Sampling temperature for the model"
     )
 
     model_config = {"extra": "forbid"}

--- a/tests/unit/test_config_models.py
+++ b/tests/unit/test_config_models.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from config_models import LLMProfile, SystemConfig
+
+
+def test_llm_profile_requires_positive_temperature() -> None:
+    with pytest.raises(ValidationError):
+        LLMProfile(provider="gemini", model="gemini-pro", temperature=0)
+
+
+def test_system_config_rejects_non_positive_temperature() -> None:
+    data = {
+        "version": "1.0",
+        "llm_profiles": {
+            "default": {
+                "provider": "gemini",
+                "model": "gemini-pro",
+                "temperature": -0.1,
+            }
+        },
+        "agents": {},
+        "tasks": {},
+        "teams": {},
+    }
+    with pytest.raises(ValidationError):
+        SystemConfig.from_dict(data)


### PR DESCRIPTION
## Summary
- require LLM profile temperature to be greater than zero
- add tests covering non-positive temperature values

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: No such file or directory)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688faa4656348321875778bc069f393a