### PR TITLE
feat: add simple orchestrator example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# 100-ai-test
+
+Projeto de exemplo para o sistema de Meta-Orquestração.
+
+## Exemplo
+
+Para executar o exemplo simples do orquestrador:
+
+```bash
+python examples/run_orchestrator.py
+```
+
+O script carrega `system_config.yaml`, valida a configuração com `ConfigValidator`
+ e inicia uma interação em linha de comando onde é possível digitar uma pergunta
+e receber a resposta do orquestrador.

--- a/examples/run_orchestrator.py
+++ b/examples/run_orchestrator.py
@@ -1,0 +1,42 @@
+"""Run a simple MetaOrchestrator demo.
+
+This script loads the system configuration, validates it using
+:class:`ConfigValidator` and starts a minimal interactive loop where the
+user can type a prompt and receive the orchestrator's response.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+from config_models import SystemConfig
+from src.core.config_validator import ConfigValidator
+from src.core.interfaces import UserRequest
+from src.core.meta_orchestrator import MetaOrchestrator
+
+
+def load_config(path: str) -> SystemConfig:
+    """Load and validate a :class:`SystemConfig` from ``path``."""
+    with open(path, encoding="utf-8") as file:
+        data: dict[str, Any] = yaml.safe_load(file)
+    config = SystemConfig.from_dict(data)
+    ConfigValidator(config).validate()
+    return config
+
+
+def main() -> None:
+    """Entry point for running the orchestrator demo."""
+    config = load_config("system_config.yaml")
+    print(f"Loaded config version {config.version}")
+    orchestrator = MetaOrchestrator()
+
+    user_input = input("Digite sua pergunta: ")
+    request = UserRequest(text=user_input)
+    response = orchestrator.execute(request)
+    print(response.text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `examples/run_orchestrator.py` demo that loads and validates `SystemConfig`
- document how to run the orchestrator example in `README`

## Testing
- `python validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py` *(fails: file not found)*
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688faa3da1c08321a1afe8e2d23a49b0