### PR TITLE
Move config validator and add interface check script

### DIFF
--- a/AI_AGENTS_GUIDE.md
+++ b/AI_AGENTS_GUIDE.md
@@ -583,10 +583,12 @@ class NovaStrategy(IExecutionStrategy):
 
 ### Scripts Úteis
 
-- `validate_config.py` - Valida arquivos de configuração YAML. Execute
-  `python validate_config.py system_config.yaml` para checar o arquivo. O
-  script escreve no console `INFO: Configuração validada com sucesso.` quando
+- `scripts/validate_config.py` - Valida arquivos de configuração YAML. Execute
+  `python scripts/validate_config.py system_config.yaml` para checar o arquivo.
+  O script escreve no console `INFO: Configuração validada com sucesso.` quando
   tudo estiver correto ou `ERROR: ...` detalhando qualquer problema.
+- `scripts/validate_interfaces.py` - Verifica se todas as classes em
+  `src/strategies` implementam `IExecutionStrategy`.
 - `python -m pytest` - Execução de testes
 
 -----

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -1,11 +1,9 @@
 import logging
 import sys
+from pathlib import Path
 
 import yaml
 from pydantic import ValidationError
-
-from config_models import SystemConfig
-from src.core.config_validator import ConfigValidator
 
 logging.basicConfig(
     level=logging.INFO,
@@ -16,6 +14,12 @@ logger = logging.getLogger(__name__)
 
 
 def main(path: str) -> int:
+    root = Path(__file__).resolve().parent.parent
+    if str(root) not in sys.path:
+        sys.path.append(str(root))
+    from config_models import SystemConfig
+    from src.core.config_validator import ConfigValidator
+
     logger.info("Validando arquivo de configuração: %s", path)
 
     try:
@@ -50,6 +54,8 @@ def main(path: str) -> int:
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        logger.error("Uso: python validate_config.py <caminho_para_config.yaml>")
+        logger.error(
+            "Uso: python scripts/validate_config.py <caminho_para_config.yaml>"
+        )
         sys.exit(1)
     sys.exit(main(sys.argv[1]))

--- a/scripts/validate_interfaces.py
+++ b/scripts/validate_interfaces.py
@@ -1,0 +1,64 @@
+import importlib
+import inspect
+import logging
+import pkgutil
+import sys
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s: %(message)s",
+    stream=sys.stdout,
+)
+logger = logging.getLogger(__name__)
+
+
+def _iter_strategy_modules():
+    package_dir = Path(__file__).resolve().parent.parent / "src" / "strategies"
+    for module_info in pkgutil.iter_modules([str(package_dir)]):
+        if module_info.name.startswith("_"):
+            continue
+        module_name = f"src.strategies.{module_info.name}"
+        yield importlib.import_module(module_name)
+
+
+def _is_concrete(cls: type) -> bool:
+    return not bool(getattr(cls, "__abstractmethods__", False))
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    if str(root) not in sys.path:
+        sys.path.append(str(root))
+    from src.core.interfaces import IExecutionStrategy
+
+    expected_sig = inspect.signature(IExecutionStrategy.execute)
+    try:
+        for module in _iter_strategy_modules():
+            logger.info("Verificando módulo: %s", module.__name__)
+            for _, obj in inspect.getmembers(module, inspect.isclass):
+                if obj.__module__ != module.__name__:
+                    continue
+                if not _is_concrete(obj):
+                    continue
+                if not hasattr(obj, "execute"):
+                    raise TypeError(
+                        f"{obj.__name__} não implementa método 'execute'"
+                    )
+                sig = inspect.signature(obj.execute)
+                if (
+                    sig.parameters.keys() != expected_sig.parameters.keys()
+                    or sig.return_annotation != expected_sig.return_annotation
+                ):
+                    raise TypeError(
+                        f"{obj.__name__} não segue o contrato de IExecutionStrategy"
+                    )
+    except Exception as e:  # pragma: no cover - salvaguarda
+        logger.error("Validação de interfaces falhou: %s", e)
+        return 1
+    logger.info("Todas as estratégias implementam IExecutionStrategy.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,1 +1,1 @@
-
+"""Strategy implementations package."""

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -22,4 +22,3 @@ MODULES: List[str] = [
 def test_import_module(module_name: str) -> None:
     """Import a module by name to verify it loads correctly."""
     importlib.import_module(module_name)
-

--- a/tests/unit/test_version_validation.py
+++ b/tests/unit/test_version_validation.py
@@ -8,7 +8,7 @@ import yaml
 from pydantic import ValidationError
 
 from config_models import SystemConfig
-from validate_config import main as validate_main
+from scripts.validate_config import main as validate_main
 
 
 def _load_base_config() -> dict:
@@ -30,7 +30,9 @@ def test_system_config_rejects_invalid_version() -> None:
         SystemConfig.from_dict(data)
 
 
-def test_validate_config_reports_invalid_version(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_validate_config_reports_invalid_version(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     data = _load_base_config()
     data["version"] = "2"
     cfg_path = tmp_path / "config.yaml"


### PR DESCRIPTION
## Summary
- relocate configuration validation script into dedicated `scripts/` package
- add interface validator ensuring strategies implement `IExecutionStrategy`
- update documentation and tests to reference new script locations

## Testing
- `python scripts/validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py`
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688fd1853330832195f35d8c72fd8fbc