### PR TITLE
test: cover fallback strategy warning

### DIFF
--- a/tests/test_meta_orchestrator.py
+++ b/tests/test_meta_orchestrator.py
@@ -1,3 +1,6 @@
+import logging
+import pytest
+
 from src.core.interfaces import AgentResponse, UserRequest
 from src.core.meta_orchestrator import MetaOrchestrator
 from src.strategies.basic_strategy import BasicStrategy
@@ -32,3 +35,18 @@ def test_meta_orchestrator_research_strategy() -> None:
     response = orchestrator.execute(request)
     assert isinstance(response, AgentResponse)
     assert "Researching" in response.text
+
+
+def test_select_strategy_unknown_returns_basic_and_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    orchestrator = MetaOrchestrator()
+    with caplog.at_level(logging.WARNING):
+        strategy = orchestrator.select_strategy("inexistente")
+
+    assert isinstance(strategy, BasicStrategy)
+    assert any(
+        record.levelno == logging.WARNING
+        and "Estratégia desconhecida" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- test MetaOrchestrator.select_strategy with unknown identifier to ensure BasicStrategy is returned and warning is logged

## Testing
- `python scripts/validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py`
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688fdc6f626483218b03af7ca7102a9a