### PR TITLE
Add duplicate checks for LLM profiles and teams

### DIFF
--- a/src/core/config_validator.py
+++ b/src/core/config_validator.py
@@ -52,6 +52,40 @@ class ConfigValidator:
             else:
                 seen_tasks.add(normalized)
 
+        seen_profiles: set[str] = set()
+        for profile_name in self._config.llm_profiles:
+            normalized = profile_name.lower()
+            if normalized in seen_profiles:
+                msg = f"Duplicate llm profile entry '{profile_name}'"
+                errors.append(
+                    {
+                        "type": "value_error",
+                        "loc": ("llm_profiles", profile_name),
+                        "msg": msg,
+                        "input": profile_name,
+                        "ctx": {"error": msg},
+                    }
+                )
+            else:
+                seen_profiles.add(normalized)
+
+        seen_teams: set[str] = set()
+        for team_name in self._config.teams:
+            normalized = team_name.lower()
+            if normalized in seen_teams:
+                msg = f"Duplicate team entry '{team_name}'"
+                errors.append(
+                    {
+                        "type": "value_error",
+                        "loc": ("teams", team_name),
+                        "msg": msg,
+                        "input": team_name,
+                        "ctx": {"error": msg},
+                    }
+                )
+            else:
+                seen_teams.add(normalized)
+
         for agent_name, agent in self._config.agents.items():
             if agent.llm not in self._config.llm_profiles:
                 msg = f"Unknown llm profile '{agent.llm}' for agent '{agent_name}'"

--- a/tests/unit/test_config_validator.py
+++ b/tests/unit/test_config_validator.py
@@ -61,3 +61,41 @@ def test_validate_duplicate_entries() -> None:
     message = str(exc.value)
     assert "Duplicate agent entry" in message
     assert "Duplicate task entry" in message
+
+
+def test_validate_duplicate_llm_profiles() -> None:
+    data = {
+        "version": "1.0",
+        "llm_profiles": {
+            "default": {"provider": "gemini", "model": "gemini-pro"},
+            "Default": {"provider": "gemini", "model": "gemini-pro"},
+        },
+        "agents": {"researcher": {"description": "desc", "llm": "default"}},
+        "tasks": {"answer": {"description": "desc", "agent": "researcher"}},
+        "teams": {"default": {"agents": ["researcher"]}},
+    }
+    config = SystemConfig.from_dict(data)
+    validator = ConfigValidator(config)
+    with pytest.raises(ValidationError) as exc:
+        validator.validate()
+    message = str(exc.value)
+    assert "Duplicate llm profile entry" in message
+
+
+def test_validate_duplicate_teams() -> None:
+    data = {
+        "version": "1.0",
+        "llm_profiles": {"default": {"provider": "gemini", "model": "gemini-pro"}},
+        "agents": {"researcher": {"description": "desc", "llm": "default"}},
+        "tasks": {"answer": {"description": "desc", "agent": "researcher"}},
+        "teams": {
+            "default": {"agents": ["researcher"]},
+            "Default": {"agents": ["researcher"]},
+        },
+    }
+    config = SystemConfig.from_dict(data)
+    validator = ConfigValidator(config)
+    with pytest.raises(ValidationError) as exc:
+        validator.validate()
+    message = str(exc.value)
+    assert "Duplicate team entry" in message


### PR DESCRIPTION
## Summary
- validate duplicate `llm_profiles` and `teams` entries in config
- add tests for duplicate profiles and teams in config validator

## Testing
- `python -m flake8 src/core/config_validator.py tests/unit/test_config_validator.py`
- `python scripts/validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py`
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688fde98239883218a9bc67267b956d7