### PR TITLE
forbid extra fields in interface models

### DIFF
--- a/src/core/interfaces.py
+++ b/src/core/interfaces.py
@@ -8,11 +8,15 @@ class UserRequest(BaseModel):
 
     text: str
 
+    model_config = {"extra": "forbid"}
+
 
 class AgentResponse(BaseModel):
     """Representa a resposta gerada por um agente."""
 
     text: str
+
+    model_config = {"extra": "forbid"}
 
 
 class IExecutionStrategy(Protocol):

--- a/tests/unit/test_interfaces_models.py
+++ b/tests/unit/test_interfaces_models.py
@@ -1,0 +1,14 @@
+import pytest
+from pydantic import ValidationError
+
+from src.core.interfaces import AgentResponse, UserRequest
+
+
+def test_user_request_rejects_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        UserRequest(text="hello", unexpected="field")  # type: ignore[call-arg]
+
+
+def test_agent_response_rejects_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        AgentResponse(text="hi", extra="value")  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary
- use Pydantic `model_config` with `extra="forbid"` for `UserRequest` and `AgentResponse`
- silence mypy on extra-field validation tests with `type: ignore`
- remove trailing blank line flagged by flake8

## Testing
- `python scripts/validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py`
- `mypy tests/unit/test_interfaces_models.py`
- `flake8`
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688fe18a963883219ec9b8b6562886cb