### PR TITLE
docs: document system_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,9 @@ python examples/run_orchestrator.py
 ```
 
 O script carrega `system_config.yaml`, valida a configuração com `ConfigValidator`
- e inicia uma interação em linha de comando onde é possível digitar uma pergunta
+e inicia uma interação em linha de comando onde é possível digitar uma pergunta
 e receber a resposta do orquestrador.
+
+## Configuração do Sistema
+
+Detalhes sobre o formato de `system_config.yaml` e como validá-lo estão descritos em [docs/system_config.md](docs/system_config.md).

--- a/docs/system_config.md
+++ b/docs/system_config.md
@@ -1,0 +1,43 @@
+# System Configuration
+
+The `system_config.yaml` file defines how the orchestrator runs. The main fields are:
+
+- **`version`**: Semantic version of the configuration schema.
+- **`llm_profiles`**: Named Large Language Model profiles with provider, model, and optional parameters such as temperature.
+- **`agents`**: Definitions of specialized agents and which LLM profile each uses.
+- **`tasks`**: Available tasks and the agent responsible for each task.
+- **`teams`**: Groups of agents that can collaborate to accomplish tasks.
+
+## Example
+
+```yaml
+version: "1.0"
+llm_profiles:
+  default:
+    provider: gemini
+    model: gemini-pro
+    temperature: 0.7
+agents:
+  researcher:
+    description: "General knowledge assistant"
+    llm: default
+tasks:
+  answer_question:
+    description: "Answer user questions"
+    agent: researcher
+teams:
+  default:
+    agents:
+      - researcher
+```
+
+## Validation
+
+To validate a configuration file before use, run:
+
+```bash
+python scripts/validate_config.py system_config.yaml
+```
+
+This command checks the file against the Pydantic models and custom rules.
+


### PR DESCRIPTION
## Summary
- add documentation for `system_config.yaml`
- link configuration docs in README

## Testing
- `python scripts/validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py`
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688ffc91fe088321b6b0b90abe9dcebb