### PR TITLE
refactor: update imports to personal_agent

### DIFF
--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -18,7 +18,7 @@ def main(path: str) -> int:
     if str(root) not in sys.path:
         sys.path.append(str(root))
     from config_models import SystemConfig
-    from src.core.config_validator import ConfigValidator
+    from personal_agent.core.config_validator import ConfigValidator
 
     logger.info("Validando arquivo de configuração: %s", path)
 

--- a/scripts/validate_interfaces.py
+++ b/scripts/validate_interfaces.py
@@ -17,11 +17,13 @@ logger = logging.getLogger(__name__)
 
 
 def _iter_strategy_modules() -> Iterator[ModuleType]:
-    package_dir = Path(__file__).resolve().parent.parent / "src" / "strategies"
+    package_dir = (
+        Path(__file__).resolve().parent.parent / "personal_agent" / "strategies"
+    )
     for module_info in pkgutil.iter_modules([str(package_dir)]):
         if module_info.name.startswith("_"):
             continue
-        module_name = f"src.strategies.{module_info.name}"
+        module_name = f"personal_agent.strategies.{module_info.name}"
         yield importlib.import_module(module_name)
 
 
@@ -33,7 +35,7 @@ def main() -> int:
     root = Path(__file__).resolve().parent.parent
     if str(root) not in sys.path:
         sys.path.append(str(root))
-    from src.core.interfaces import IExecutionStrategy
+    from personal_agent.core.interfaces import IExecutionStrategy
 
     expected_sig = inspect.signature(IExecutionStrategy.execute)
     try:

--- a/tests/test_meta_orchestrator.py
+++ b/tests/test_meta_orchestrator.py
@@ -1,10 +1,14 @@
 import logging
 import pytest
 
-from src.core.interfaces import AgentResponse, IExecutionStrategy, UserRequest
-from src.core.meta_orchestrator import MetaOrchestrator
-from src.strategies.basic_strategy import BasicStrategy
-from src.strategies.research_strategy import ResearchStrategy
+from personal_agent.core.interfaces import (
+    AgentResponse,
+    IExecutionStrategy,
+    UserRequest,
+)
+from personal_agent.core.meta_orchestrator import MetaOrchestrator
+from personal_agent.strategies.basic_strategy import BasicStrategy
+from personal_agent.strategies.research_strategy import ResearchStrategy
 
 
 def test_meta_orchestrator_basic_strategy() -> None:

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -7,14 +7,14 @@ import pytest
 
 
 MODULES: List[str] = [
-    "src",
-    "src.core",
-    "src.agents",
-    "src.strategies",
-    "src.tools",
-    "src.memory",
-    "src.utils",
-    "src.adapters",
+    "personal_agent",
+    "personal_agent.core",
+    "personal_agent.agents",
+    "personal_agent.strategies",
+    "personal_agent.tools",
+    "personal_agent.memory",
+    "personal_agent.utils",
+    "personal_agent.adapters",
 ]
 
 

--- a/tests/unit/test_basic_strategy.py
+++ b/tests/unit/test_basic_strategy.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 import pytest
 
-from src.core.interfaces import AgentResponse, UserRequest
-from src.strategies.basic_strategy import BasicStrategy
+from personal_agent.core.interfaces import AgentResponse, UserRequest
+from personal_agent.strategies.basic_strategy import BasicStrategy
 
 
 def test_basic_strategy_execute_returns_expected_response(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/unit/test_config_validator.py
+++ b/tests/unit/test_config_validator.py
@@ -5,7 +5,7 @@ import yaml
 from pydantic import ValidationError
 
 from config_models import SystemConfig
-from src.core.config_validator import ConfigValidator
+from personal_agent.core.config_validator import ConfigValidator
 
 
 def load_config(path: str) -> SystemConfig:

--- a/tests/unit/test_interfaces_models.py
+++ b/tests/unit/test_interfaces_models.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from src.core.interfaces import AgentResponse, UserRequest
+from personal_agent.core.interfaces import AgentResponse, UserRequest
 
 
 def test_user_request_rejects_extra_fields() -> None:

--- a/tests/unit/test_research_strategy.py
+++ b/tests/unit/test_research_strategy.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 import pytest
 
-from src.core.interfaces import AgentResponse, UserRequest
-from src.strategies.research_strategy import ResearchStrategy
+from personal_agent.core.interfaces import AgentResponse, UserRequest
+from personal_agent.strategies.research_strategy import ResearchStrategy
 
 
 def test_research_strategy_execute_returns_expected_response(

--- a/tests/unit/test_simple_rag.py
+++ b/tests/unit/test_simple_rag.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import pytest
 
-from src.memory.simple_rag import SimpleRAG
+from personal_agent.memory.simple_rag import SimpleRAG
 
 
 def test_add_documents_stores_texts(caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Summary
- update validation scripts to import from personal_agent package
- replace src.* imports with personal_agent.* throughout tests
- adjust interface validator to scan personal_agent strategies

## Testing
- `python scripts/validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py`
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688ffc620164832185c2e3d0f5d75475