### PR TITLE
Fix orchestrator demo imports

### DIFF
--- a/examples/run_orchestrator.py
+++ b/examples/run_orchestrator.py
@@ -12,9 +12,9 @@ from typing import Any
 import yaml
 
 from config_models import SystemConfig
-from src.core.config_validator import ConfigValidator
-from src.core.interfaces import UserRequest
-from src.core.meta_orchestrator import MetaOrchestrator
+from personal_agent.core.config_validator import ConfigValidator
+from personal_agent.core.interfaces import UserRequest
+from personal_agent.core.meta_orchestrator import MetaOrchestrator
 
 
 def load_config(path: str) -> SystemConfig:


### PR DESCRIPTION
## Summary
- update orchestrator example to import from `personal_agent.core`

## Testing
- `python scripts/validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py`
- `python -m pytest tests/ -v`
- `PYTHONPATH=. python examples/run_orchestrator.py`

------
https://chatgpt.com/codex/tasks/task_e_68903273f0c88321a79ce3d40ea6f28e