### PR TITLE
refactor: centralize duplicate checks in ConfigValidator

### DIFF
--- a/personal_agent/core/config_validator.py
+++ b/personal_agent/core/config_validator.py
@@ -14,77 +14,39 @@ class ConfigValidator:
     def __init__(self, config: SystemConfig) -> None:
         self._config = config
 
+    def _check_duplicates(
+        self,
+        section_data: dict[str, Any],
+        section_name: str,
+        errors: list[dict[str, Any]],
+    ) -> None:
+        """Check for case-insensitive duplicate keys in a section."""
+        seen: set[str] = set()
+        singular = section_name[:-1].replace("_", " ")
+        for item in section_data:
+            normalized = item.lower()
+            if normalized in seen:
+                msg = f"Duplicate {singular} entry '{item}'"
+                errors.append(
+                    {
+                        "type": "value_error",
+                        "loc": (section_name, item),
+                        "msg": msg,
+                        "input": item,
+                        "ctx": {"error": msg},
+                    }
+                )
+            else:
+                seen.add(normalized)
+
     def validate(self) -> None:
         """Validate configuration, raising ValidationError on issues."""
         errors: list[dict[str, Any]] = []
 
-        seen_agents: set[str] = set()
-        for agent_name in self._config.agents:
-            normalized = agent_name.lower()
-            if normalized in seen_agents:
-                msg = f"Duplicate agent entry '{agent_name}'"
-                errors.append(
-                    {
-                        "type": "value_error",
-                        "loc": ("agents", agent_name),
-                        "msg": msg,
-                        "input": agent_name,
-                        "ctx": {"error": msg},
-                    }
-                )
-            else:
-                seen_agents.add(normalized)
-
-        seen_tasks: set[str] = set()
-        for task_name in self._config.tasks:
-            normalized = task_name.lower()
-            if normalized in seen_tasks:
-                msg = f"Duplicate task entry '{task_name}'"
-                errors.append(
-                    {
-                        "type": "value_error",
-                        "loc": ("tasks", task_name),
-                        "msg": msg,
-                        "input": task_name,
-                        "ctx": {"error": msg},
-                    }
-                )
-            else:
-                seen_tasks.add(normalized)
-
-        seen_profiles: set[str] = set()
-        for profile_name in self._config.llm_profiles:
-            normalized = profile_name.lower()
-            if normalized in seen_profiles:
-                msg = f"Duplicate llm profile entry '{profile_name}'"
-                errors.append(
-                    {
-                        "type": "value_error",
-                        "loc": ("llm_profiles", profile_name),
-                        "msg": msg,
-                        "input": profile_name,
-                        "ctx": {"error": msg},
-                    }
-                )
-            else:
-                seen_profiles.add(normalized)
-
-        seen_teams: set[str] = set()
-        for team_name in self._config.teams:
-            normalized = team_name.lower()
-            if normalized in seen_teams:
-                msg = f"Duplicate team entry '{team_name}'"
-                errors.append(
-                    {
-                        "type": "value_error",
-                        "loc": ("teams", team_name),
-                        "msg": msg,
-                        "input": team_name,
-                        "ctx": {"error": msg},
-                    }
-                )
-            else:
-                seen_teams.add(normalized)
+        self._check_duplicates(self._config.agents, "agents", errors)
+        self._check_duplicates(self._config.tasks, "tasks", errors)
+        self._check_duplicates(self._config.llm_profiles, "llm_profiles", errors)
+        self._check_duplicates(self._config.teams, "teams", errors)
 
         for agent_name, agent in self._config.agents.items():
             if agent.llm not in self._config.llm_profiles:


### PR DESCRIPTION
## Summary
- centralize duplicate entry detection into private helper
- simplify config validation by reusing helper across sections

## Testing
- `python scripts/validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py`
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68903362e9048321a1eeb0d66ef116a2