### PR TITLE
Handle missing documents in SimpleRAG query

### DIFF
--- a/personal_agent/memory/simple_rag.py
+++ b/personal_agent/memory/simple_rag.py
@@ -42,5 +42,7 @@ class SimpleRAG:
             List of document snippets containing the query.
         """
         lowered = question.lower()
-        matches = [doc for doc in self._docs if lowered in doc.lower()]
-        return matches[:top_k]
+        stored = {"documents": self._docs}
+        docs = stored.get("documents") or []
+        indices = [i for i, doc in enumerate(docs) if lowered in doc.lower()]
+        return [docs[i] for i in indices[:top_k]]


### PR DESCRIPTION
## Summary
- Prevent errors in `SimpleRAG.query` when no documents are stored
- Maintain document indexing for query matches

## Testing
- `python scripts/validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py`
- `python -m pytest tests/ -v`
- `mypy personal_agent/memory/simple_rag.py`


------
https://chatgpt.com/codex/tasks/task_e_68904dce758c8321a6dd315cf91c89a1