### PR TITLE
docs: document SimpleRAG model and add requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,17 @@ e receber a resposta do orquestrador.
 ## Configuração do Sistema
 
 Detalhes sobre o formato de `system_config.yaml` e como validá-lo estão descritos em [docs/system_config.md](docs/system_config.md).
+
+## Modelo de Embeddings
+
+`SimpleRAG` utiliza um modelo da biblioteca [`sentence-transformers`](https://www.sbert.net) para gerar embeddings de texto.
+O modelo padrão é `"all-MiniLM-L6-v2"`. Na primeira execução, os pesos são baixados automaticamente.
+
+Em ambientes sem acesso à internet, o download pode ser feito manualmente em outra máquina:
+
+```bash
+python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2').save('./all-MiniLM-L6-v2')"
+```
+
+Depois, copie a pasta `all-MiniLM-L6-v2` para o ambiente restrito e defina a variável
+`SENTENCE_TRANSFORMERS_HOME` apontando para esse diretório ou informe o caminho ao instanciar o `SentenceTransformer`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ flake8
 numpy>=1.21
 pydantic>=2.0
 PyYAML
+chromadb
+sentence-transformers


### PR DESCRIPTION
## Summary
- document SentenceTransformer usage in SimpleRAG and offline download steps
- add chromadb and sentence-transformers to requirements

## Testing
- `python scripts/validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py`
- `PYTHONPATH=. pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_6890535b6e188321ae09066004f2d148