### PR TITLE
Use ChromaDB-backed RAG with sentence-transformers

### DIFF
--- a/personal_agent/memory/README.md
+++ b/personal_agent/memory/README.md
@@ -1,15 +1,15 @@
 # SimpleRAG Memory Module
 
-`SimpleRAG` fornece um armazenamento em memória para experimentos iniciais de Retrieval-Augmented Generation (RAG).
-Ele mantém uma lista de textos e realiza buscas por substring para recuperar documentos relevantes.
+`SimpleRAG` fornece um armazenamento persistente baseado em ChromaDB para experimentos de Retrieval-Augmented Generation (RAG).
+Ele utiliza um modelo da biblioteca [`sentence-transformers`](https://www.sbert.net) para gerar embeddings e realiza busca semântica sobre os documentos.
 
 ## Limitações Atuais
-- Todo o conteúdo é mantido apenas em memória; não há persistência em disco.
-- Busca ingênua por substring, sem embeddings ou ranking semântico.
-- Ausência de metadados, controle de concorrência ou otimizações para grandes volumes.
+- Ausência de metadados avançados ou controle de concorrência.
+- Dependência direta do ChromaDB para persistência.
+- Ausência de otimizações para grandes volumes de dados.
 
 ## Plano de Evolução
-1. **MVP:** conectar o módulo a um vector store simples (ChromaDB) para busca semântica.
+1. **Iteração atual:** utilizar ChromaDB para busca semântica com embeddings `all-MiniLM-L6-v2`.
 2. **Iteração 3:** migrar para uma memória híbrida Grafo-Vetor baseada em Neo4j, conforme descrito no [Plano de Arquitetura](../../Plano_de_arquitetura.md).
 3. Integrar um `ArchivistAgent` para gerenciar ingestão, versionamento e poda de documentos.
 

--- a/tests/unit/test_simple_rag.py
+++ b/tests/unit/test_simple_rag.py
@@ -1,26 +1,31 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
+
 import pytest
 
 from personal_agent.memory.simple_rag import SimpleRAG
 
 
-def test_add_documents_stores_texts(caplog: pytest.LogCaptureFixture) -> None:
-    rag = SimpleRAG()
+def test_add_documents_stores_texts(
+    caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    rag = SimpleRAG(persist_directory=str(tmp_path))
     texts = ["First doc", "Second Doc"]
 
     with caplog.at_level(logging.INFO):
         rag.add_documents(texts)
 
-    assert rag._docs == texts
+    results = rag.query("First doc", top_k=2)
     assert "Added 2 documents" in caplog.text
+    assert "First doc" in results
 
 
-def test_query_returns_matching_docs_case_insensitive() -> None:
-    rag = SimpleRAG()
+def test_query_returns_matching_docs_case_insensitive(tmp_path: Path) -> None:
+    rag = SimpleRAG(persist_directory=str(tmp_path))
     rag.add_documents(["Python is great", "I love coding", "PYTHON typing"])
 
     results = rag.query("python", top_k=2)
 
-    assert results == ["Python is great", "PYTHON typing"]
+    assert set(results) == {"Python is great", "PYTHON typing"}


### PR DESCRIPTION
## Summary
- Replace in-memory SimpleRAG with persistent ChromaDB collection and shared SentenceTransformer embeddings
- Update tests and docs for persistent, semantic search workflow

## Testing
- `python scripts/validate_config.py system_config.yaml`
- `python scripts/validate_interfaces.py`
- `PYTHONPATH=$(pwd) pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68905595122c8321bc718c3cb11c0fc1