### PR TITLE
chore: tidy simple RAG imports

### DIFF
--- a/personal_agent/memory/simple_rag.py
+++ b/personal_agent/memory/simple_rag.py
@@ -15,9 +15,11 @@ import string
 import uuid
 from collections import Counter
 from typing import List
+
 import chromadb
 from chromadb.api.models.Collection import Collection
 import numpy as np
+
 logger = logging.getLogger(__name__)
 
 
@@ -97,4 +99,3 @@ class SimpleRAG:
         scores = np.dot(embs, embedding) / norms
         ranked = np.argsort(scores)[::-1][:top_k]
         return [docs[i] for i in ranked]
-      


### PR DESCRIPTION
## Summary
- ensure simple_rag imports string and Counter, grouping imports cleanly
- trim trailing whitespace and add final newline

## Testing
- `flake8 personal_agent/memory/simple_rag.py`


------
https://chatgpt.com/codex/tasks/task_e_6890b2ba92a48321a927e8d09cb32757